### PR TITLE
Update Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,8 @@
+MIRROR=http://mirror.rackspace.com/archlinux/iso
 VERSION=$(shell date +"%Y.%m").01
 IMAGE=archlinux-${VERSION}-x86_64.iso
 
 iso:
-	curl -o ${IMAGE} http://mirror.rackspace.com/archlinux/iso/${VERSION}/${IMAGE}
-	curl -o ${IMAGE}.sig https://www.archlinux.org/iso/${VERSION}/${IMAGE}.sig
+	curl -o ${IMAGE} ${MIRROR}/${VERSION}/${IMAGE}
+	curl -o ${IMAGE}.sig ${MIRROR}/${VERSION}/${IMAGE}.sig
 	gpg --auto-key-retrieve --verify ${IMAGE}.sig


### PR DESCRIPTION
curl -o ${IMAGE}.sig https://www.archlinux.org/iso/${VERSION}/${IMAGE}.sig
had failed with "gpg no valid openpgp data found. gpg the signature could not be verified" because it was HTML telling about "forbidden"